### PR TITLE
remove send/sync retrictions when possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 benchmark/
+Cargo.lock

--- a/src/hamt.rs
+++ b/src/hamt.rs
@@ -60,8 +60,7 @@ enum BorrowedNodeRef<'a, K, V, IS, H>
 }
 
 impl<K, V, IS, H> NodeRef<K, V, IS, H>
-    where K: Eq+Send+Sync,
-          V: Send+Sync,
+    where K: Eq,
           IS: ItemStore<K, V>,
           H: Hasher
 {
@@ -183,9 +182,7 @@ enum NodeEntryRef<'a, K, V, IS, H>
 }
 
 impl<'a, K, V, IS, H> NodeEntryRef<'a, K, V, IS, H>
-    where K: Send+Sync,
-          V: Send+Sync,
-          IS: ItemStore<K, V>
+    where IS: ItemStore<K, V>
 {
     // Clones the contents of a NodeEntryRef into a NodeEntryOwned value to be used elsewhere.
     fn clone_out(&self) -> NodeEntryOwned<K, V, IS, H> {
@@ -406,8 +403,7 @@ impl<'a, K, V, IS, H> UnsafeNode<K, V, IS, H>
 
 // impl UnsafeNode (continued)
 impl<K, V, IS, H> UnsafeNode<K, V, IS, H>
-    where K: Eq+Send+Sync+Hash,
-          V: Send+Sync,
+    where K: Eq+Hash,
           IS: ItemStore<K, V>,
           H: Hasher+Default
 {
@@ -1159,8 +1155,7 @@ pub struct HamtMap<K, V, IS=ShareStore<K,V>, H=StdHasher> {
 
 // impl HamtMap
 impl<K, V, IS, H> HamtMap<K, V, IS, H>
-    where K: Eq+Send+Sync+Hash,
-          V: Send+Sync,
+    where K: Eq+Hash,
           IS: ItemStore<K, V>,
           H: Hasher+Default
 {
@@ -1336,8 +1331,7 @@ impl<K, V, IS, H> Clone for HamtMap<K, V, IS, H> {
 
 // Default for HamtMap
 impl<K, V, IS, H> Default for HamtMap<K, V, IS, H>
-    where K: Eq+Send+Sync+Hash,
-          V: Send+Sync,
+    where K: Eq+Hash,
           IS: ItemStore<K, V>,
           H: Hasher+Default
 {
@@ -1347,8 +1341,8 @@ impl<K, V, IS, H> Default for HamtMap<K, V, IS, H>
 }
 
 impl<'a, K, V, IS, H> IntoIterator for &'a HamtMap<K, V, IS, H>
-    where K: Eq+Send+Sync+Hash+'a,
-          V: Send+Sync+'a,
+    where K: Eq+Hash+'a,
+          V: 'a,
           IS: ItemStore<K, V>+'a,
           H: Hasher+Default+'a
 {
@@ -1363,8 +1357,8 @@ impl<'a, K, V, IS, H> IntoIterator for &'a HamtMap<K, V, IS, H>
 
 // Eq for HamtMap
 impl<K, V, IS, H> PartialEq for HamtMap<K, V, IS, H>
-    where K: Eq+Send+Sync+Hash,
-          V: PartialEq+Send+Sync,
+    where K: Eq+Hash,
+          V: PartialEq,
           IS: ItemStore<K, V>,
           H: Hasher+Default
 {
@@ -1397,8 +1391,8 @@ impl<K, V, IS, H> PartialEq for HamtMap<K, V, IS, H>
 
 // Eq for HamtMap
 impl<K, V, IS, H> Eq for HamtMap<K, V, IS, H>
-    where K: Eq+Send+Sync+Hash,
-          V: Eq+Send+Sync,
+    where K: Eq+Hash,
+          V: Eq,
           IS: ItemStore<K, V>,
           H: Hasher+Default
 {
@@ -1407,8 +1401,7 @@ impl<K, V, IS, H> Eq for HamtMap<K, V, IS, H>
 
 // FromIterator
 impl<K, V, IS, H> ::std::iter::FromIterator<(K, V)> for HamtMap<K, V, IS, H>
-    where K: Eq+Send+Sync+Hash,
-          V: Send+Sync,
+    where K: Eq+Hash,
           IS: ItemStore<K, V>,
           H: Hasher+Default
 {
@@ -1467,8 +1460,7 @@ pub struct HamtMapIterator<'a, K, V, IS, H>
 
 impl<'a, K, V, IS, H>
 HamtMapIterator<'a, K, V, IS, H>
-    where K: Eq+Send+Sync,
-          V: Send+Sync,
+    where K: Eq,
           IS: ItemStore<K, V>,
           H: Hasher
 {
@@ -1486,8 +1478,7 @@ HamtMapIterator<'a, K, V, IS, H>
 
 impl<'a, K, V, IS, H>
 Iterator for HamtMapIterator<'a, K, V, IS, H>
-    where K: Eq+Send+Sync,
-          V: Send+Sync,
+    where K: Eq,
           IS: ItemStore<K, V>,
           H: 'a + Hasher
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,6 @@
 
 extern crate libc;
 
-extern crate rand;
-
 pub use hamt::HamtMap;
 pub use hamt::HamtMapIterator;
 pub use item_store::{ItemStore, ShareStore, CopyStore};


### PR DESCRIPTION
Because HamtMap isn't Send/Sync, there's no reason to make K or V Send or Sync.  

This removes the necessity in the API, while allowing for the possibility of a Sync/Send HamptMap in the future.